### PR TITLE
fix: 输入为 TypeScript 时不调用构造函数

### DIFF
--- a/src/models/san-project.ts
+++ b/src/models/san-project.ts
@@ -60,7 +60,7 @@ export class SanProject {
         if (/\.ts$/.test(filePath)) {
             if (!this.tsProject) throw new Error(`Error parsing ${input}, tsconfig not specified`)
             const sourceFile = this.createOrRefreshSourceFile(this.tsProject, filePath, fileContent)
-            return new TypeScriptSanParser(sourceFile).parse()
+            return new TypeScriptSanParser().parse(sourceFile)
         }
         return new ComponentClassParser(require(filePath), filePath).parse()
     }

--- a/test/unit/parsers/typescript-san-parser.spec.ts
+++ b/test/unit/parsers/typescript-san-parser.spec.ts
@@ -12,8 +12,26 @@ describe('.parseFromTypeScript()', () => {
         class Foo extends Component {}
         export default class Bar extends Component {}
         `)
-        const sourceFile = new TypeScriptSanParser(file).parse()
+        const sourceFile = new TypeScriptSanParser().parse(file)
         expect(sourceFile.componentInfos[0].classDeclaration.isDefaultExport()).toBe(false)
         expect(sourceFile.componentInfos[1].classDeclaration.isDefaultExport()).toBe(true)
+    })
+
+    it('should remove constructors', function () {
+        const file = proj.createSourceFile('foo.ts', `
+            import { Component } from 'san'
+            function foo () {}
+            export class MyComponent extends Component {
+                foo = 'bar'
+                constructor() {
+                    foo()
+                }
+            }
+        `)
+        const sourceFile = new TypeScriptSanParser().parse(file)
+        expect(sourceFile.componentInfos).toHaveLength(1)
+
+        const [info] = sourceFile.componentInfos
+        expect(info.classDeclaration.getConstructors()).toHaveLength(0)
     })
 })

--- a/test/unit/target-js/index.spec.ts
+++ b/test/unit/target-js/index.spec.ts
@@ -12,7 +12,7 @@ describe('ToJSCompiler', () => {
                 import { Component } from 'san';
                 class Foo extends Component {}
             `)
-            expect(() => cc.compileToSource(new TypeScriptSanParser(sourceFile).parse())).not.toThrow()
+            expect(() => cc.compileToSource(new TypeScriptSanParser().parse(sourceFile))).not.toThrow()
         })
     })
 })


### PR DESCRIPTION
原则上 SSR 期间不调用 san 核心代码，构造函数会调用基类，而基类在 san 核心里，因此违反了这一点。