### PR TITLE
fix: 字面量对象为undefined时转换出错

### DIFF
--- a/src/target-js/js-emitter.ts
+++ b/src/target-js/js-emitter.ts
@@ -193,7 +193,7 @@ export class JSEmitter extends Emitter {
             return LITERAL_DATE_INDICATOR + this.getTime()
         }
         // 利用 toJSON 不能直接实现，因为 JS Date 无法表达为 JSON 字符串。
-        const str = JSON.stringify(node.value).replace(LITERAL_DATE_MATCHER, 'new Date($1)');
+        const str = node.value === undefined ? 'undefined' : JSON.stringify(node.value).replace(LITERAL_DATE_MATCHER, 'new Date($1)');
         (Date.prototype as any).toJSON = toJSON
 
         return this.write(str)


### PR DESCRIPTION
ssr 渲染时，组件初始化值为`undefined`，执行到 `JSON.stringify(node.value).replace(LITERAL_DATE_MATCHER, 'new Date($1)');`时报错`annot read property 'replace' of undefined `，因为`node.value`为`undefined`时`JSON.stringify(node.value)`为`undefined`而不是`string`类型。