### PR TITLE
fix: renderOnly should backward compatible with old version

### DIFF
--- a/src/ast/renderer-ast-dfn.ts
+++ b/src/ast/renderer-ast-dfn.ts
@@ -58,6 +58,7 @@ export enum SyntaxKind {
     RegexpReplace = 28,
     JSONStringify = 29,
     HelperCall = 30,
+    GetRootCtxCall = 31,
     ComponentReferenceLiteral = 32,
     SlotRendererDefinition = 33,
     SlotRenderCall = 34,
@@ -72,7 +73,7 @@ export enum SyntaxKind {
 export type Expression = Identifier | FunctionDefinition | Literal | BinaryExpression | UnaryExpression |
     CreateComponentInstance | NewExpression | MapLiteral | ComponentRendererReference | FunctionCall | Null |
     Undefined | MapAssign | ArrayIncludes | ConditionalExpression | FilterCall | HelperCall | EncodeURIComponent |
-    ArrayLiteral | RegexpReplace | JSONStringify | ComputedCall | ComponentReferenceLiteral |
+    ArrayLiteral | RegexpReplace | JSONStringify | ComputedCall | GetRootCtxCall | ComponentReferenceLiteral |
     SlotRendererDefinition | SlotRenderCall | ComponentClassReference | CreateComponentPrototype | Typeof
 
 export type Statement = ReturnStatement | ImportHelper | VariableDefinition | AssignmentStatement | If | ElseIf | Else |
@@ -85,7 +86,7 @@ export type UnaryOperator = '!' | '~' | '+' | '()' | '-'
 export class ArrayLiteral implements SyntaxNode {
     public readonly kind = SyntaxKind.ArrayLiteral
     constructor (
-        public items: [Expression, boolean][] // [item, isSpread]
+        public items: [Expression, boolean][]
     ) {}
 }
 
@@ -302,6 +303,13 @@ export class FilterCall implements SyntaxNode {
     public readonly kind = SyntaxKind.FilterCall
     constructor (
         public name: string,
+        public args: Expression[]
+    ) {}
+}
+
+export class GetRootCtxCall implements SyntaxNode {
+    public readonly kind = SyntaxKind.GetRootCtxCall
+    constructor (
         public args: Expression[]
     ) {}
 }

--- a/src/ast/renderer-ast-walker.ts
+++ b/src/ast/renderer-ast-walker.ts
@@ -48,6 +48,7 @@ export function * walk (node: Expression | Statement): Iterable<Expression | Sta
         yield * walk(node.trueValue)
         break
     case SyntaxKind.FilterCall:
+    case SyntaxKind.GetRootCtxCall:
     case SyntaxKind.HelperCall:
         for (const arg of node.args) yield * walk(arg)
         break

--- a/src/compilers/anode-compiler.ts
+++ b/src/compilers/anode-compiler.ts
@@ -14,7 +14,7 @@ import * as TypeGuards from '../ast/san-ast-type-guards'
 import { IDGenerator } from '../utils/id-generator'
 import {
     JSONStringify, RegexpReplace, Statement, SlotRendererDefinition, ElseIf, Else, MapAssign, Foreach, If, MapLiteral,
-    ComponentRendererReference, FunctionCall, SlotRenderCall, Expression, ComponentReferenceLiteral,
+    ComponentRendererReference, FunctionCall, SlotRenderCall, Expression, GetRootCtxCall, ComponentReferenceLiteral,
     ComponentClassReference,
     VariableDefinition,
     ConditionalExpression,
@@ -253,7 +253,9 @@ export class ANodeCompiler {
             BINARY(
                 BINARY(I('info'), '.', I('rootOutputData')),
                 '||',
-                BINARY(I('ctx'), '.', I('data'))
+
+                // 这里保留 GetRootCtxCall 是为了兼容与老版本 san-ssr 的编译产物混用的情况
+                BINARY(new GetRootCtxCall([I('ctx')]), '.', I('data'))
             )
         )
         const outputDataExpr = BINARY(I('info'), '.', I('outputData'))

--- a/src/runtime/underscore.ts
+++ b/src/runtime/underscore.ts
@@ -179,6 +179,19 @@ function createInstanceFromClass (Clazz: Component<{}> & ComponentDefineOptions)
     return instance
 }
 
+function getRootCtx<T extends {parentCtx?: T}> (ctx: T) {
+    let last = ctx
+    while (ctx.parentCtx) {
+        last = ctx
+        ctx = ctx.parentCtx
+    }
+
+    // 如果跟组件 render 调用的时候传递了 parentCtx，会找到这个对象
+    // 通过 ctx 是否有 data 来判断是不是真正的 rootCtx
+    // @ts-ignore
+    return ctx.data ? ctx : last
+}
+
 function handleError (e: Error, instance: Component<{}>, info: string) {
     let current: Component<{}> | undefined = instance
     while (current) {
@@ -221,6 +234,7 @@ export const _ = {
     xstyleFilter,
     xclassFilter,
     createFromPrototype,
+    getRootCtx,
     iterate,
     callFilter,
     callComputed,

--- a/src/target-js/js-emitter.ts
+++ b/src/target-js/js-emitter.ts
@@ -90,6 +90,11 @@ export class JSEmitter extends Emitter {
             this.writeExpressionList(node.args)
             this.write(')')
             break
+        case SyntaxKind.GetRootCtxCall:
+            this.write('_.getRootCtx(')
+            this.writeExpressionList(node.args)
+            this.write(')')
+            break
         case SyntaxKind.HelperCall:
             this.write(`_.${node.name}(`)
             this.writeExpressionList(node.args)


### PR DESCRIPTION
change
```javascript
let data = info.renderOnly ? ctx.data : info.rootOutputData || ctx.data
```
to
```javascript
let data = info.renderOnly ? ctx.data : info.rootOutputData || _.getRootCtx(ctx).data
```
The `ctx.data` part should only use on the root component.

But, when some components are compiled with 3.13.0, and other components are compiled with older versions, there will be no `info.rootOutputData` in older components.
