### PR TITLE
优化 ssr 产物代码体积

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,8 @@
         "san-ssr-target-fake-cmd": "^1.0.0",
         "san-ssr-target-fake-esm": "^1.0.0",
         "source-map-support": "^0.5.19",
-        "swig-templates": "^2.0.3"
+        "swig-templates": "^2.0.3",
+        "terser": "^5.43.1"
       },
       "optionalDependencies": {
         "@semantic-release/changelog": "^6.0.1",
@@ -2667,6 +2668,51 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2fgen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2fresolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2fsource-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2fsourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.30",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2ftrace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -16292,10 +16338,11 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "http://registry.npm.baidu-int.com/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -16818,6 +16865,43 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.43.1",
+      "resolved": "http://registry.npm.baidu-int.com/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "http://registry.npm.baidu-int.com/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "http://registry.npm.baidu-int.com/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -19835,6 +19919,48 @@
         "@types/node": "*",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0"
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2fgen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2fresolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2fsource-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2fsourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.30",
+      "resolved": "http://registry.npm.baidu-int.com/@jridgewell%2ftrace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "@nodelib/fs.scandir": {
@@ -30503,9 +30629,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "http://registry.npm.baidu-int.com/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -30936,6 +31062,32 @@
       "requires": {
         "ansi-escapes": "^4.2.1",
         "supports-hyperlinks": "^2.0.0"
+      }
+    },
+    "terser": {
+      "version": "5.43.1",
+      "resolved": "http://registry.npm.baidu-int.com/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.15.0",
+          "resolved": "http://registry.npm.baidu-int.com/acorn/-/acorn-8.15.0.tgz",
+          "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "http://registry.npm.baidu-int.com/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        }
       }
     },
     "test-exclude": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "san-ssr-target-fake-cmd": "^1.0.0",
     "san-ssr-target-fake-esm": "^1.0.0",
     "source-map-support": "^0.5.19",
-    "swig-templates": "^2.0.3"
+    "swig-templates": "^2.0.3",
+    "terser":"^5.43.1"
   },
   "optionalDependencies": {
     "@semantic-release/changelog": "^6.0.1",

--- a/src/ast/renderer-ast-dfn.ts
+++ b/src/ast/renderer-ast-dfn.ts
@@ -79,7 +79,7 @@ export type Expression = Identifier | FunctionDefinition | Literal | BinaryExpre
 export type Statement = ReturnStatement | ImportHelper | VariableDefinition | AssignmentStatement | If | ElseIf | Else |
     Foreach | ExpressionStatement | TryStatement
 
-export type BinaryOperator = '+' | '-' | '*' | '/' | '.' | '===' | '!==' | '||' | '&&' | '[]' | '+=' | '!=' | '=='
+export type BinaryOperator = '+' | '-' | '*' | '/' | '%' | '.' | '===' | '!==' | '||' | '&&' | '[]' | '+=' | '!=' | '==' | '<' | '<=' | '>' | '>='
 
 export type UnaryOperator = '!' | '~' | '+' | '()' | '-'
 

--- a/src/compilers/element-compiler.ts
+++ b/src/compilers/element-compiler.ts
@@ -62,7 +62,7 @@ export class ElementCompiler {
         }
 
         // element properties
-        const propsIndex = {}
+        const propsIndex = {} as { [key: string]: AProperty }
         for (const prop of props) propsIndex[prop.name] = prop
         const propsAttrAssign = {}
         if (componentInfo.inheritAttrs) {

--- a/src/compilers/renderer-compiler.ts
+++ b/src/compilers/renderer-compiler.ts
@@ -20,6 +20,18 @@ import { mergeLiteralAdd } from '../optimizers/merge-literal-add'
 import { RESERVED_NAMES } from './reserved-names'
 
 /**
+ * helper 常用函数别名，有利于减少代码压缩体积
+ */
+export const helperAliases = new Map<string, string>([
+    ['attrFilter', '_attrFilter'],
+    ['escapeHTML', '_escapeHTML'],
+    ['classFilter', '_classFilter'],
+    ['styleFilter', '_styleFilter'],
+    ['iterate', '_iterate'],
+    ['output', '_output']
+])
+
+/**
  * 每个 ComponentClass 对应一个 Render 函数，由 RendererCompiler 生成。
  */
 export class RendererCompiler {
@@ -158,6 +170,9 @@ export class RendererCompiler {
 
         // helper
         body.push(new ImportHelper('_'))
+        for (const [name, alias] of helperAliases) {
+            body.push(DEF(alias, BINARY(I('_'), '.', I(name))))
+        }
         body.push(new ImportHelper('SanSSRData'))
 
         if (this.options.useProvidedComponentClass) {
@@ -268,6 +283,9 @@ export class RendererCompiler {
 
         // helper
         body.push(new ImportHelper('_'))
+        for (const [name, alias] of helperAliases) {
+            body.push(DEF(alias, BINARY(I('_'), '.', I(name))))
+        }
 
         // instance preraration
         if (info.hasMethod('initData')) {

--- a/src/compilers/san-expr-compiler.ts
+++ b/src/compilers/san-expr-compiler.ts
@@ -9,7 +9,8 @@ import * as TypeGuards from '../ast/san-ast-type-guards'
 import { _ } from '../runtime/underscore'
 import {
     EncodeURIComponent, MapLiteral, HelperCall, ArrayLiteral, FilterCall, FunctionCall, Identifier,
-    ConditionalExpression, BinaryExpression, UnaryExpression, Expression
+    ConditionalExpression, BinaryExpression, UnaryExpression, Expression,
+    BinaryOperator
 } from '../ast/renderer-ast-dfn'
 import { CTX_DATA, L, I, NULL } from '../ast/renderer-ast-util'
 import {
@@ -42,7 +43,7 @@ export enum OutputType {
 }
 
 // 二元表达式操作符映射表
-const binaryOp = {
+const binaryOp: Record<string, BinaryOperator> = {
     37: '%',
     43: '+',
     45: '-',

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -47,7 +47,7 @@ export type FilePath = string
 export type CompileInput = SanFileDescriptor | FileDescriptor | FilePath | ComponentClass
 
 export function isFileDescriptor (input: CompileInput): input is FileDescriptor {
-    return typeof input['filePath'] === 'string' && typeof input['fileContent'] === 'string'
+    return typeof (input as FileDescriptor)['filePath'] === 'string' && typeof (input as FileDescriptor)['fileContent'] === 'string'
 }
 
 export function isComponentClass (input: CompileInput): input is ComponentClass {
@@ -55,5 +55,5 @@ export function isComponentClass (input: CompileInput): input is ComponentClass 
 }
 
 export function isSanFileDescriptor (input: CompileInput): input is SanFileDescriptor {
-    return typeof input['templateContent'] === 'string'
+    return typeof (input as SanFileDescriptor)['templateContent'] === 'string'
 }

--- a/src/parsers/component-class-parser.ts
+++ b/src/parsers/component-class-parser.ts
@@ -13,6 +13,10 @@ import { parseAndNormalizeTemplate } from './parse-template'
 import { componentID, DynamicComponentReference } from '../models/component-reference'
 import { COMPONENT_REFERENCE } from '../helpers/markExternalComponent'
 
+function isExternalComponent<T extends Record<string, any>> (component: T): component is T & { [COMPONENT_REFERENCE]: DynamicComponentReference } {
+    return !!component[COMPONENT_REFERENCE]
+}
+
 /*
  * ComponentClass 解析器
  *
@@ -128,7 +132,7 @@ export class ComponentClassParser {
             }
 
             // 外部组件
-            if (componentClass[COMPONENT_REFERENCE]) {
+            if (isExternalComponent(componentClass)) {
                 children.set(tagName, componentClass[COMPONENT_REFERENCE])
                 continue
             }

--- a/src/parsers/javascript-san-parser.ts
+++ b/src/parsers/javascript-san-parser.ts
@@ -7,7 +7,7 @@
 import debugFactory from 'debug'
 import { ancestor } from 'acorn-walk'
 import { Node as AcornNode, parse } from 'acorn'
-import { CallExpression, Program, Node, Class, ObjectExpression } from 'estree'
+import { CallExpression, Program, Node, Class, ObjectExpression, MemberExpression, Identifier } from 'estree'
 import { generate } from 'astring'
 import { ComponentType, JSComponentInfo } from '../models/component-info'
 import {
@@ -197,11 +197,11 @@ export class JavaScriptSanParser {
         }
         // exports.Foo = Component
         if (isAssignmentExpression(parent) && isExportsMemberExpression(parent.left)) {
-            return this.createComponent(node, getStringValue(parent.left['property']))
+            return this.createComponent(node, getStringValue((parent.left as MemberExpression)['property']))
         }
         // const Foo = Component
         if (isVariableDeclarator(parent)) {
-            return this.createComponent(node, parent.id['name'])
+            return this.createComponent(node, (parent.id as Identifier)['name'])
         }
         // Foo = Component
         if (isAssignmentExpression(parent) && isIdentifier(parent.left)) {
@@ -279,7 +279,7 @@ export class JavaScriptSanParser {
         } else if (isObjectExpression(node)) {
             deletePropertiesFromObject(node, name)
         } else {
-            deletePropertiesFromObject(node['arguments'][0], name)
+            deletePropertiesFromObject((node as CallExpression)['arguments'][0] as ObjectExpression, name)
         }
 
         deleteMemberAssignmentsTo(this.root, targetName, name)
@@ -288,7 +288,7 @@ export class JavaScriptSanParser {
     private * getPropertiesFromComponentDeclaration (node: Node, name: string) {
         if (this.isComponentClass(node)) yield * getMembersFromClassDeclaration(node as Class)
         else if (isObjectExpression(node)) yield * getPropertiesFromObject(node)
-        else yield * getPropertiesFromObject(node['arguments'][0])
+        else yield * getPropertiesFromObject((node as CallExpression)['arguments'][0] as ObjectExpression)
         yield * getMemberAssignmentsTo(this.root, name)
     }
 

--- a/src/runtime/resolver.ts
+++ b/src/runtime/resolver.ts
@@ -118,10 +118,10 @@ export function createResolver (exports: {[key: string]: any}, require: nodeRequ
             exports.sanSSRRenders[id] = fn
         },
         getPrototype: function (id: string) {
-            return this['prototypes'][id]
+            return (this as any)['prototypes'][id]
         },
         setPrototype: function (id: string, proto: any) {
-            this['prototypes'][id] = proto
+            (this as any)['prototypes'][id] = proto
         },
         prototypes: {}
     } as Resolver

--- a/src/runtime/underscore.ts
+++ b/src/runtime/underscore.ts
@@ -35,7 +35,7 @@ const rENTITY = new RegExp(`[${Object.keys(HTML_ENTITY).join('')}]`, 'g')
 
 function escapeHTML (source: any) {
     if (typeof source === 'string') {
-        return source.replace(rENTITY, (c: string) => HTML_ENTITY[c])
+        return source.replace(rENTITY, (c: string) => HTML_ENTITY[c as keyof typeof HTML_ENTITY])
     }
     return source
 }
@@ -78,7 +78,7 @@ function styleFilter (source: object | string) {
         const keys = Object.keys(source)
         let res = ''
         for (let i = 0; i < keys.length; i++) {
-            const key = keys[i]
+            const key = keys[i] as keyof typeof source
             res += (key + ':' + source[key] + ';')
         }
         return res
@@ -107,7 +107,7 @@ function xstyleFilter (inherits: object | string, own: string) {
 
 function attrFilter (name: string, value: string | number | boolean, needEscape: boolean) {
     // style/class/id 值为 falsy 时不输出属性
-    if (value == null || (!value && BASE_PROPS[name])) {
+    if (value == null || (!value && BASE_PROPS[name as keyof typeof BASE_PROPS])) {
         return ''
     }
     value = '' + value
@@ -175,7 +175,7 @@ function createInstanceFromClass (Clazz: Component<{}> & ComponentDefineOptions)
     if (initData) Clazz.prototype.initData = initData
     if (components) Clazz.prototype.components = components
     Clazz.prototype.template = template
-    if (computed) instance['computed'] = Clazz.prototype.computed = Clazz.computed = computed
+    if (computed) (instance as any)['computed'] = Clazz.prototype.computed = Clazz.computed = computed
     return instance
 }
 

--- a/src/target-js/compilers/component-compiler.ts
+++ b/src/target-js/compilers/component-compiler.ts
@@ -46,7 +46,7 @@ export class ComponentClassCompiler {
         }
     }
 
-    private emitMembers (componentProto: Object) {
+    private emitMembers (componentProto: Record<string, any>) {
         const { emitter } = this
         for (const key of Object.getOwnPropertyNames(componentProto)) {
             const member = componentProto[key]

--- a/src/target-js/js-emitter.ts
+++ b/src/target-js/js-emitter.ts
@@ -2,6 +2,7 @@ import {
     Literal, Foreach, FunctionDefinition, ArrayLiteral, UnaryExpression, MapLiteral, Statement, SyntaxKind, Expression,
     VariableDefinition, SlotRendererDefinition
 } from '../ast/renderer-ast-dfn'
+import { helperAliases } from '../compilers/renderer-compiler'
 import { Emitter } from '../utils/emitter'
 import { assertNever } from '../utils/lang'
 
@@ -96,7 +97,7 @@ export class JSEmitter extends Emitter {
             this.write(')')
             break
         case SyntaxKind.HelperCall:
-            this.write(`_.${node.name}(`)
+            this.write(`${helperAliases.has(node.name) ? `${helperAliases.get(node.name)}` : `_.${node.name}`}(`)
             this.writeExpressionList(node.args)
             this.write(')')
             break

--- a/src/utils/lang.ts
+++ b/src/utils/lang.ts
@@ -5,7 +5,7 @@ export function isValidIdentifier (str: string) {
 export function getMemberFromClass<T> (clazz: Function, property: string, defaultValue: T): T
 export function getMemberFromClass<T> (clazz: Function, property: string): T | undefined
 export function getMemberFromClass<T> (clazz: Function, property: string, defaultValue?: T): T | undefined {
-    if (clazz[property] !== undefined) return clazz[property]
+    if ((clazz as any)[property] !== undefined) return (clazz as any)[property]
     if (clazz.prototype && clazz.prototype[property] !== undefined) {
         return clazz.prototype[property]
     }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -9,8 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "downlevelIteration": true,
-    "strict": false,
-    "suppressImplicitAnyIndexErrors": true
+    "strict": false
   },
   "all": true,
   "exclude": [ "node_modules", "dist" ]

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,20 +1,46 @@
 import { compileToSource, compileToRenderer } from '../../src/index'
 import { defineComponent } from 'san'
+import terser from 'terser'
 
 describe('compileToSource', function () {
     it('should compile ComponentClass to JavaScript code', function () {
         const ComponentClass = defineComponent({ template: '<span>A</span>' })
         const code = compileToSource(ComponentClass as any)
-
         expect(code).toContain('html += "A')
         expect(code).toMatch(/^function render \(data, info\) {/)
+    })
+
+    it('should use aliased helper name in compiled Component code', async function () {
+        const ComponentClass = defineComponent({ template: '<span>A</span>' })
+        const code = compileToSource(ComponentClass as any)
+
+        expect(code).toContain('_attrFilter = _.attrFilter')
+        expect(code).toContain('_escapeHTML = _.escapeHTML')
+        expect(code).toContain('_classFilter = _.classFilter')
+        expect(code).toContain('_styleFilter = _.styleFilter')
+        expect(code).toContain('_iterate = _.iterate')
+        expect(code).toContain('_output = _.output')
+        const compressed = await terser.minify({
+            'code.js': code
+        }, {
+            mangle: true
+        })
+        // helper 压缩后变量名会变成 a,b,c 等短名称
+        expect(compressed.code).toMatch(/[a-z]=[a-z]\.attrFilter/)
+        expect(compressed.code).toMatch(/[a-z]=[a-z]\.escapeHTML/)
+        expect(compressed.code).toMatch(/[a-z]=[a-z]\.classFilter/)
+        expect(compressed.code).toMatch(/[a-z]=[a-z]\.styleFilter/)
+        expect(compressed.code).toMatch(/[a-z]=[a-z]\.attrFilter/)
+        // 移除未使用的 helper
+        expect(compressed.code).not.toMatch(/[a-z]=[a-z]\.iterate/)
+        expect(compressed.code).not.toMatch(/[a-z]=[a-z]\.output/)
     })
 })
 
 describe('compileToRenderer', function () {
     it('should compile to a renderer function', function () {
         const ComponentClass = defineComponent({ template: '<span>A</span>' })
-        const render = compileToRenderer(ComponentClass)
+        const render = compileToRenderer(ComponentClass as unknown as san.Component)
 
         expect(render).toBeInstanceOf(Function)
         expect(render({}, {
@@ -24,7 +50,7 @@ describe('compileToRenderer', function () {
 
     it('should compile to a renderer function which accepts data', function () {
         const ComponentClass = defineComponent({ template: '<span>name: {{name}}</span>' })
-        const render = compileToRenderer(ComponentClass)
+        const render = compileToRenderer(ComponentClass as unknown as san.Component)
 
         expect(render).toBeInstanceOf(Function)
         expect(render({ name: 'Harttle' }, {
@@ -35,7 +61,7 @@ describe('compileToRenderer', function () {
     it('should run inited only in run time', function () {
         const inited = jest.fn()
         const ComponentClass = defineComponent({ inited, template: '<div>a</div>' })
-        const render = compileToRenderer(ComponentClass)
+        const render = compileToRenderer(ComponentClass as unknown as san.Component)
 
         expect(inited).not.toBeCalled()
         expect(render({}, {

--- a/test/unit/models/san-project.spec.ts
+++ b/test/unit/models/san-project.spec.ts
@@ -90,7 +90,7 @@ describe('SanProject', function () {
             })
 
             expect(code).toContain('html += "<div"')
-            expect(code).toContain('html += _.output(ctx.data.name, true)')
+            expect(code).toContain('html += _output(ctx.data.name, true)')
             expect(code).toContain('html += "</div>"')
         })
     })
@@ -109,7 +109,7 @@ describe('SanProject', function () {
         it('the noDataOutput parameter should be optional and default to false', function () {
             const proj = new SanProject()
             const componentClass = defineComponent({ template: '<div>{{name}}</div>' })
-            const render = proj.compileToRenderer(componentClass)
+            const render = proj.compileToRenderer(componentClass as unknown as san.Component<{}>)
 
             expect(render).toBeInstanceOf(Function)
             expect(render({ name: 'Harttle' })).toEqual('<div><!--s-data:{"name":"Harttle"}-->Harttle</div>')
@@ -118,7 +118,7 @@ describe('SanProject', function () {
         it('should escape consecutive hyphen', function () {
             const proj = new SanProject()
             const componentClass = defineComponent({ template: '<div>{{ a + b + c + d }}</div>' })
-            const render = proj.compileToRenderer(componentClass)
+            const render = proj.compileToRenderer(componentClass as unknown as san.Component<{}>)
 
             expect(render({
                 a: -3,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
     "downlevelIteration": true,
     "strict": true,
     "sourceMap": true,
-    "baseUrl": "types",
-    "suppressImplicitAnyIndexErrors": true
+    "baseUrl": "types"
   },
   "include": [ "src" ]
 }


### PR DESCRIPTION
## 对 ssr helper 常用函数生成别名，产物压缩后可减少 2% 左右的代码体积，有利于内存优化：
常用函数如下：

- attrFilter
- escapeHTML
- classFilter
- styleFilter
- iterate
- output

## 修复 ts 类型报错
修复因移除 suppressImplicitAnyIndexErrors 导致的 ts 报错